### PR TITLE
Update res_partner.py

### DIFF
--- a/partner_create_by_vat/res_partner.py
+++ b/partner_create_by_vat/res_partner.py
@@ -23,6 +23,7 @@
 
 import datetime
 import time
+import unicodedata
 
 from string import maketrans
 import requests
@@ -118,6 +119,8 @@ class res_partner(models.Model):
                         if jud.lower().startswith('municip'):
                             jud = ' '.join(jud.split(' ')[1:])
                         if jud != '':
+                            jud=jud.replace('-', '%').replace(' ', '%') #for states with " " or "-"
+                            jud=unicodedata.normalize('NFKD', jud).encode('ascii','ignore')
                             state = self.env['res.country.state'].search(
                                 [('name', 'ilike', jud)])
                             if state:


### PR DESCRIPTION
now it will recognize and complete the state - if you set up your postgresql to find unaccented texts.
-sudo apt-get install postgresql-contrib-9.3   
- psql DATABASE -c "CREATE EXTENSION \"unaccent\"";
  if you do not want to use unnacented postgresql, we must normalize also res.country.state.name at compare
